### PR TITLE
feat: Enable thumbnail support for venues

### DIFF
--- a/includes/class-wpevents-cpt.php
+++ b/includes/class-wpevents-cpt.php
@@ -125,7 +125,7 @@ class WPEvents_CPT {
             ],
             'public' => true,
             'show_in_rest' => true,
-            'supports' => [ 'title' ],
+            'supports' => [ 'title', 'thumbnail' ],
             'rewrite' => [ 'slug' => 'venues' ],
             'show_in_menu' => 'edit.php?post_type=event',
             'taxonomies' => [ 'venue_category' ],


### PR DESCRIPTION
Adds 'thumbnail' to the 'supports' array for the 'venue' custom post type registration in includes/class-wpevents-cpt.php. This allows users to add featured images to venues, which was a missing feature compared to the other custom post types in the plugin.